### PR TITLE
Fix HttpContext is null.

### DIFF
--- a/src/Log4Net.Async/AsyncForwardingAppenderBase.cs
+++ b/src/Log4Net.Async/AsyncForwardingAppenderBase.cs
@@ -31,11 +31,11 @@
         {
             get
             {
-                return CallContext.GetData("HtCt");
+                return CallContext.HostContext;
             }
             set
             {
-                CallContext.SetData("HtCt", value);
+                CallContext.HostContext = value;
             }
         }
 


### PR DESCRIPTION
Fixes #2 

I am able to log with aspnet-context and aspnet-request with patternlayout.

Since, to my knowledge, HttpContext cannot be mocked, I don't believe there is a way to create a unit test for this.   I created a test project using a trace appender to verify that these work.  Let me know if you want that added to the project.

