### PR TITLE
Fix Issue #29

### DIFF
--- a/src/Log4Net.Async.Tests/ParallelForwarderTest.cs
+++ b/src/Log4Net.Async.Tests/ParallelForwarderTest.cs
@@ -43,19 +43,19 @@ namespace Log4Net.Async.Tests
             LogManager.Shutdown();
         }
 
-		[Test]
-		public void NoExceptionThrownWhenCancelBeforeEndAndNoEvent()
-		{
-			// Arrange
-
-			// Act
-			asyncForwardingAppender.Close();
-
-			// Assert
-			Assert.That(debugAppender.LoggedEventCount, Is.EqualTo(0), "No message or exception expected");
-		}
-
-		[Test]
+        [Test]
+        public void NoExceptionThrownWhenCancelBeforeEndAndNoEvent()
+        {
+            // Arrange
+            
+            // Act
+            asyncForwardingAppender.Close();
+            
+            // Assert
+            Assert.That(debugAppender.LoggedEventCount, Is.EqualTo(0), "No message or exception expected");
+        }
+        
+        [Test]
         public void CanHandleNullLoggingEvent()
         {
             // Arrange

--- a/src/Log4Net.Async.Tests/ParallelForwarderTest.cs
+++ b/src/Log4Net.Async.Tests/ParallelForwarderTest.cs
@@ -43,7 +43,20 @@ namespace Log4Net.Async.Tests
             LogManager.Shutdown();
         }
 
-        [Test]
+		[Test]
+		public void NoExceptionThrownWhenNoEvent()
+		{
+			// Arrange
+
+			// Act
+			asyncForwardingAppender.DoAppend((LoggingEvent)null);
+			asyncForwardingAppender.Close();
+
+			// Assert - should not have had an exception from previous call
+			Assert.That(debugAppender.LoggedEventCount, Is.EqualTo(0), "No message or exception expected");
+		}
+
+		[Test]
         public void CanHandleNullLoggingEvent()
         {
             // Arrange

--- a/src/Log4Net.Async.Tests/ParallelForwarderTest.cs
+++ b/src/Log4Net.Async.Tests/ParallelForwarderTest.cs
@@ -49,7 +49,7 @@ namespace Log4Net.Async.Tests
             // Arrange
             
             // Act
-            asyncForwardingAppender.Close();
+            LogManager.Shutdown();
             
             // Assert
             Assert.That(debugAppender.LoggedEventCount, Is.EqualTo(0), "No message or exception expected");

--- a/src/Log4Net.Async.Tests/ParallelForwarderTest.cs
+++ b/src/Log4Net.Async.Tests/ParallelForwarderTest.cs
@@ -44,15 +44,14 @@ namespace Log4Net.Async.Tests
         }
 
 		[Test]
-		public void NoExceptionThrownWhenNoEvent()
+		public void NoExceptionThrownWhenCancelBeforeEndAndNoEvent()
 		{
 			// Arrange
 
 			// Act
-			asyncForwardingAppender.DoAppend((LoggingEvent)null);
 			asyncForwardingAppender.Close();
 
-			// Assert - should not have had an exception from previous call
+			// Assert
 			Assert.That(debugAppender.LoggedEventCount, Is.EqualTo(0), "No message or exception expected");
 		}
 

--- a/src/Log4Net.Async/ParallelForwardingAppender.cs
+++ b/src/Log4Net.Async/ParallelForwardingAppender.cs
@@ -194,9 +194,6 @@
             //the queue is marked as adding completed, or the task is canceled.
             try
             {
-                //This is to avoid throwing an exception when there is no event
-                if (_loggingEvents.Count == 0) return;
-
                 //This call blocks until an item is available or until adding is completed
                 foreach (var entry in _loggingEvents.GetConsumingEnumerable(_loggingCancelationToken))
                 {
@@ -206,6 +203,9 @@
             }
             catch (OperationCanceledException ex)
             {
+                //This is to avoid throwing an exception when there is no event
+                if (_loggingEvents.Count == 0) return;
+
                 //The thread was canceled before all entries could be forwarded and the collection completed.
                 ForwardInternalError("Subscriber task was canceled before completion.", ex, ThisType);
                 //Cancellation is called in the CompleteSubscriberTask so don't call that again.

--- a/src/Log4Net.Async/ParallelForwardingAppender.cs
+++ b/src/Log4Net.Async/ParallelForwardingAppender.cs
@@ -123,14 +123,14 @@
             var sleepInterval = TimeSpan.FromMilliseconds(100);
             var flushTimespan = TimeSpan.FromSeconds(_shutdownFlushTimeout);
 
-			//Sleep until either timeout is expired or all events have flushed
-			while (flushTimespan >= sleepInterval && !_loggingEvents.IsCompleted)
-			{
-		        flushTimespan -= sleepInterval;
-		        Thread.Sleep(sleepInterval);
-	        }
+            //Sleep until either timeout is expired or all events have flushed
+            while (flushTimespan >= sleepInterval && !_loggingEvents.IsCompleted)
+            {
+                flushTimespan -= sleepInterval;
+                Thread.Sleep(sleepInterval);
+            }
 
-			if (!_loggingTask.IsCompleted && !_loggingCancelationToken.IsCancellationRequested)
+            if (!_loggingTask.IsCompleted && !_loggingCancelationToken.IsCancellationRequested)
             {
                 _loggingCancelationTokenSource.Cancel();
                 //Wait here so that the error logging messages do not get into a random order.
@@ -194,8 +194,8 @@
             //the queue is marked as adding completed, or the task is canceled.
             try
             {
-				//This is to avoid throwing an exception when there is no event
-	            if (_loggingEvents.Count == 0) return;
+                //This is to avoid throwing an exception when there is no event
+                if (_loggingEvents.Count == 0) return;
 
                 //This call blocks until an item is available or until adding is completed
                 foreach (var entry in _loggingEvents.GetConsumingEnumerable(_loggingCancelationToken))

--- a/src/Log4Net.Async/ParallelForwardingAppender.cs
+++ b/src/Log4Net.Async/ParallelForwardingAppender.cs
@@ -123,12 +123,12 @@
             var sleepInterval = TimeSpan.FromMilliseconds(100);
             var flushTimespan = TimeSpan.FromSeconds(_shutdownFlushTimeout);
 
-            //Sleep until either timeout is expired or all events have flushed
-	        do
-	        {
+			//Sleep until either timeout is expired or all events have flushed
+			while (flushTimespan >= sleepInterval && !_loggingEvents.IsCompleted)
+			{
 		        flushTimespan -= sleepInterval;
 		        Thread.Sleep(sleepInterval);
-	        } while (flushTimespan >= sleepInterval && !_loggingEvents.IsCompleted);
+	        }
 
 			if (!_loggingTask.IsCompleted && !_loggingCancelationToken.IsCancellationRequested)
             {
@@ -194,6 +194,9 @@
             //the queue is marked as adding completed, or the task is canceled.
             try
             {
+				//This is to avoid throwing an exception when there is no event
+	            if (_loggingEvents.Count == 0) return;
+
                 //This call blocks until an item is available or until adding is completed
                 foreach (var entry in _loggingEvents.GetConsumingEnumerable(_loggingCancelationToken))
                 {

--- a/src/Log4Net.Async/ParallelForwardingAppender.cs
+++ b/src/Log4Net.Async/ParallelForwardingAppender.cs
@@ -124,13 +124,13 @@
             var flushTimespan = TimeSpan.FromSeconds(_shutdownFlushTimeout);
 
             //Sleep until either timeout is expired or all events have flushed
-            while (flushTimespan >= sleepInterval && !_loggingEvents.IsCompleted)
-            {
-                flushTimespan -= sleepInterval;
-                Thread.Sleep(sleepInterval);
-            }
+	        do
+	        {
+		        flushTimespan -= sleepInterval;
+		        Thread.Sleep(sleepInterval);
+	        } while (flushTimespan >= sleepInterval && !_loggingEvents.IsCompleted);
 
-            if (!_loggingTask.IsCompleted && !_loggingCancelationToken.IsCancellationRequested)
+			if (!_loggingTask.IsCompleted && !_loggingCancelationToken.IsCancellationRequested)
             {
                 _loggingCancelationTokenSource.Cancel();
                 //Wait here so that the error logging messages do not get into a random order.


### PR DESCRIPTION
Immediately shutdown can throw an OperationCancelException. We should wait the first 100ms and then check if it is Completed and wait again if not.